### PR TITLE
Create CNAME file for fixprotocol.io

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+fixprotocol.io


### PR DESCRIPTION
Trying to configure our github site with the fixprotocol.io URL.
